### PR TITLE
deprecate nodejs <8.17, npm<6

### DIFF
--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -82,8 +82,8 @@ After build staging it is the `lib` folder which actually gets published to NPM.
 ## NPM/Node Version Requirements
 
 `ethjs` requires you have:
-  - `nodejs` -v 6.5.0+
-  - `npm` -v 3.0+
+  - `nodejs` -v 8.17.0+
+  - `npm` -v 6.0+
 
 This is a requirement to run, test, lint and build this module.
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "start": "npm test",
     "release": "npmpub",
     "pretest": "npm run lint",
-    "prepublish": "npm run build",
+    "prepare": "npm run build",
     "prebuild": "npm run build:clean && npm run test",
     "build:clean": "npm run test:clean && rimraf ./dist",
     "build:commonjs": "cross-env BABEL_ENV=commonjs babel src --out-dir lib --copy-files",

--- a/package.json
+++ b/package.json
@@ -156,8 +156,8 @@
     "webpack": "2.1.0-beta.15"
   },
   "engines": {
-    "npm": ">=3",
-    "node": ">=6.5.0"
+    "npm": ">=6",
+    "node": ">=8.17.0"
   },
   "keywords": [
     "ethereum",


### PR DESCRIPTION
- nodejs boron (v6) entered maintenance on 2016-10-18 and EOL since 2019-04-30. It is not considered in active use anymore.
  - `prepublish` is no longer a lifecycle script starting with npm v5.