### PR TITLE
test against @metamask/ethjs-query as well as legacy ethjs-query

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -797,6 +797,76 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "@metamask/ethjs-format": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@metamask/ethjs-format/-/ethjs-format-0.3.0.tgz",
+      "integrity": "sha512-Q0FhY/e7XYmP4y7qMhM3Fv86Z0kO+mont8BqBogDMOMvSa8bzjPy94XRKHarIcYICyCL9Kp2zGHVTuQR2J+JtA==",
+      "dev": true,
+      "requires": {
+        "@metamask/ethjs-util": "^0.3.0",
+        "@metamask/number-to-bn": "^1.7.1",
+        "bn.js": "^5.2.1",
+        "ethjs-schema": "0.2.1",
+        "is-hex-prefixed": "1.0.0",
+        "strip-hex-prefix": "1.0.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+          "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
+          "dev": true
+        }
+      }
+    },
+    "@metamask/ethjs-query": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@metamask/ethjs-query/-/ethjs-query-0.7.0.tgz",
+      "integrity": "sha512-RiPKOAjoT+685DienKu8iLNWKwgUM7RoZmPMt0AFh7rljE7JE/7zztjWcCkmwRPcKwyFjJdXJggX9V/fcpcw1g==",
+      "dev": true,
+      "requires": {
+        "@metamask/ethjs-format": "^0.3.0",
+        "@metamask/ethjs-rpc": "^0.3.1",
+        "promise-to-callback": "^1.0.0"
+      }
+    },
+    "@metamask/ethjs-rpc": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@metamask/ethjs-rpc/-/ethjs-rpc-0.3.1.tgz",
+      "integrity": "sha512-NT2KIsqTANj1prKseuazzfLhtHQtKiTOknCHylrShUyLW+8lLJUCaHQL1Y9XPg/1MQXYGBad7TShOXqGWX2kcg==",
+      "dev": true,
+      "requires": {
+        "promise-to-callback": "^1.0.0"
+      }
+    },
+    "@metamask/ethjs-util": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@metamask/ethjs-util/-/ethjs-util-0.3.0.tgz",
+      "integrity": "sha512-BXOEPmzDAzbsizZSW/wRW+58FBfj3K/1/jd7pZ9mKCOwlUCqhv8nyiiGTXQItRo+PH+GeuRGiR/IxuvSfw3CnQ==",
+      "dev": true,
+      "requires": {
+        "is-hex-prefixed": "1.0.0",
+        "strip-hex-prefix": "1.0.0"
+      }
+    },
+    "@metamask/number-to-bn": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@metamask/number-to-bn/-/number-to-bn-1.7.1.tgz",
+      "integrity": "sha512-qCN+Au4amvcVii2LdOJNndYhdmk5Lk9tlStJhKpZ8tGeYQDJTghqYXJuSUVPHvfl6FUfKY1i1Or2j2EbnEerSQ==",
+      "dev": true,
+      "requires": {
+        "bn.js": "5.2.1",
+        "strip-hex-prefix": "1.0.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+          "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
+          "dev": true
+        }
+      }
+    },
     "@nicolo-ribaudo/chokidar-2": {
       "version": "2.1.8-no-fsevents.3",
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.3.tgz",
@@ -3982,6 +4052,12 @@
         }
       }
     },
+    "ethjs-schema": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/ethjs-schema/-/ethjs-schema-0.2.1.tgz",
+      "integrity": "sha512-DXd8lwNrhT9sjsh/Vd2Z+4pfyGxhc0POVnLBUfwk5udtdoBzADyq+sK39dcb48+ZU+2VgtwHxtGWnLnCfmfW5g==",
+      "dev": true
+    },
     "ethjs-unit": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/ethjs-unit/-/ethjs-unit-0.1.6.tgz",
@@ -5702,6 +5778,12 @@
       "requires": {
         "call-bind": "^1.0.2"
       }
+    },
+    "is-fn": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fn/-/is-fn-1.0.0.tgz",
+      "integrity": "sha512-XoFPJQmsAShb3jEQRfzf2rqXavq7fIqF/jOekp308JlThqrODnMpweVSGilKTCXELfLhltGP2AGgbQGVP8F1dg==",
+      "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
@@ -7730,6 +7812,16 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
+    "promise-to-callback": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/promise-to-callback/-/promise-to-callback-1.0.0.tgz",
+      "integrity": "sha512-uhMIZmKM5ZteDMfLgJnoSq9GCwsNKrYau73Awf1jIy6/eUcuuZ3P+CD9zUv0kJsIUbU+x6uLNIhXhLHDs1pNPA==",
+      "dev": true,
+      "requires": {
+        "is-fn": "^1.0.0",
+        "set-immediate-shim": "^1.0.1"
+      }
+    },
     "prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -8598,6 +8690,12 @@
         "functions-have-names": "^1.2.3",
         "has-property-descriptors": "^1.0.0"
       }
+    },
+    "set-immediate-shim": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+      "integrity": "sha512-Li5AOqrZWCVA2n5kryzEmqai6bKSIvpz5oUJHPVj6+dsbD3X1ixtsY5tEnsaNpH3pFAHmG8eIHUrtEtohrg+UQ==",
+      "dev": true
     },
     "set-value": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "@babel/plugin-transform-property-literals": "^7.0.0",
     "@babel/plugin-transform-object-rest-spread": "^7.0.0",
     "@babel/register": "^7.0.0",
+    "@metamask/ethjs-query": "^0.7.0",
     "babel-loader": "^8.0.0",
     "chai": "^4.3.10",
     "cross-env": "^6.0.3",

--- a/src/tests/test.index.js
+++ b/src/tests/test.index.js
@@ -122,7 +122,7 @@ describe('HttpProvider', () => {
         eth.getBalance(accountsResult[0], (balanceError, balanceResult) => {
           assert.equal(balanceError, null);
           assert.equal(typeof balanceResult, 'object');
-          assert.equal(balanceResult.toNumber(10) > 0, true);
+          assert.equal(balanceResult.toString(), '100000000000000000000');
 
           done();
         });
@@ -137,7 +137,7 @@ describe('HttpProvider', () => {
         eth.getBalance(accountResult, (balanceError, balanceResult) => {
           assert.equal(balanceError, null);
           assert.equal(typeof balanceResult, 'object');
-          assert.equal(balanceResult.toNumber(10) > 0, true);
+          assert.equal(balanceResult.toString(), '100000000000000000000');
 
           done();
         });

--- a/src/tests/test.index.js
+++ b/src/tests/test.index.js
@@ -1,6 +1,7 @@
 const HttpProvider = require('../index.js'); // eslint-disable-line
 const TestRPC = require('ganache-cli'); // eslint-disable-line
 const Eth = require('ethjs-query'); // eslint-disable-line
+const MMEth = require('@metamask/ethjs-query');
 const EthQuery = require('eth-query');
 const Web3 = require('web3');
 const assert = require('chai').assert; // eslint-disable-line
@@ -96,6 +97,51 @@ describe('HttpProvider', () => {
         new HttpProvider(); // eslint-disable-line
       }
       assert.throws(invalidProvider, Error);
+    });
+  });
+
+  describe('test against @metamask/ethjs-query', () => {
+    const eth = new MMEth(new HttpProvider('http://localhost:5002'));
+
+    it('should get accounts', (done) => {
+      eth.accounts((accountsError, accountsResult) => {
+        assert.equal(accountsError, null);
+        assert.equal(typeof accountsResult, 'object');
+        assert.equal(Array.isArray(accountsResult), true);
+
+        done();
+      });
+    });
+
+    it('should get balances', (done) => {
+      eth.accounts((accountsError, accountsResult) => {
+        assert.equal(accountsError, null);
+        assert.equal(typeof accountsResult, 'object');
+        assert.equal(Array.isArray(accountsResult), true);
+
+        eth.getBalance(accountsResult[0], (balanceError, balanceResult) => {
+          assert.equal(balanceError, null);
+          assert.equal(typeof balanceResult, 'object');
+          assert.equal(balanceResult.toNumber(10) > 0, true);
+
+          done();
+        });
+      });
+    });
+
+    it('should get coinbase and balance', (done) => {
+      eth.coinbase((accountsError, accountResult) => {
+        assert.equal(accountsError, null);
+        assert.equal(typeof accountResult, 'string');
+
+        eth.getBalance(accountResult, (balanceError, balanceResult) => {
+          assert.equal(balanceError, null);
+          assert.equal(typeof balanceResult, 'object');
+          assert.equal(balanceResult.toNumber(10) > 0, true);
+
+          done();
+        });
+      });
     });
   });
 


### PR DESCRIPTION
- Test against `@metamask/ethjs-query` using same tests as `ethjs-query` 
  - Keeping legacy version around until compatibility is explicitly broken